### PR TITLE
Shorten the task “research tree”

### DIFF
--- a/lib/src/game_screen/project_picker_modal.dart
+++ b/lib/src/game_screen/project_picker_modal.dart
@@ -10,7 +10,8 @@ class ProjectPickerModal extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     var taskPool = Provider.of<TaskPool>(context);
-    var _tasks = taskPool.availableTasks.toList(growable: false);
+    var _tasks = taskPool.availableTasks.toList(growable: false)
+      ..sort((a, b) => -a.priority.compareTo(b.priority));
 
     return ListView.builder(
       itemCount: _tasks.length + 1,

--- a/lib/src/game_screen/skill_badge.dart
+++ b/lib/src/game_screen/skill_badge.dart
@@ -38,7 +38,7 @@ class SkillBadge extends StatelessWidget {
         child: Text(
           skillDisplayName[skill] +
               (value != null ? " (${value.round()})" : ""),
-          style: TextStyle(fontSize: 10.0, color: Colors.white),
+          style: const TextStyle(fontSize: 10.0, color: Colors.white),
         ),
       ),
     );

--- a/lib/src/shared_state/game/task_blueprint.dart
+++ b/lib/src/shared_state/game/task_blueprint.dart
@@ -10,22 +10,37 @@ class TaskBlueprint implements Prerequisite {
   final String name;
 
   final Map<Skill, double> difficulty;
-  List<Skill> get skillsNeeded => difficulty.keys.toList(growable: false);
 
   /// The tasks (and their combinations) that the player must have completed
   /// before this task is available.
   final Prerequisite requirements;
 
   final int userReward;
+
   final int coinReward;
+
+  /// When sorting several blueprints, the ones with higher priority
+  /// come first. This is `0` by default.
+  final int priority;
+
+  /// List of names of tasks that, when started, immediately make this task
+  /// not selectable. For example, starting a 'Red Design' disallows
+  /// 'Blue Design'.
+  final List<String> mutuallyExclusive;
 
   const TaskBlueprint(this.name, this.difficulty,
       {@required this.requirements,
       this.userReward = 100,
-      this.coinReward = 80})
+      this.coinReward = 80,
+      this.priority = 0,
+      this.mutuallyExclusive = const []})
       : assert(name != null),
         assert(difficulty != null),
-        assert(requirements != null);
+        assert(requirements != null),
+        assert(priority != null),
+        assert(mutuallyExclusive != null);
+
+  List<Skill> get skillsNeeded => difficulty.keys.toList(growable: false);
 
   /// The task is satisfied if, and only if, it has already been done.
   @override

--- a/lib/src/shared_state/game/task_prerequisite.dart
+++ b/lib/src/shared_state/game/task_prerequisite.dart
@@ -35,31 +35,6 @@ class AnyOf implements Prerequisite {
   }
 }
 
-/// A prerequisite that is satisfied only if the [child] is _not_ satisfied.
-///
-/// Use this when you want two tasks to be mutually exclusive.
-///
-/// Because we can't construct two tasks that depend on each other, this
-/// operator takes the [TaskBlueprint.name] instead of the
-/// [TaskBlueprint] itself.
-class Not implements Prerequisite {
-  final String name;
-
-  const Not(this.name);
-
-  @override
-  bool isSatisfiedIn(Iterable<Prerequisite> done) {
-    for (final prerequisite in done) {
-      if (prerequisite is! TaskBlueprint) {
-        throw ArgumentError(
-            'Not was used with non-TaskBlueprint argument: $prerequisite');
-      }
-      if ((prerequisite as TaskBlueprint).name == name) return false;
-    }
-    return true;
-  }
-}
-
 /// An abstract class representing something that can be satisfied or not.
 ///
 /// Implemented by operators ([AnyOf], [AllOf]) and by [TaskBlueprint].

--- a/lib/src/shared_state/game/task_tree/animations.dart
+++ b/lib/src/shared_state/game/task_tree/animations.dart
@@ -3,7 +3,7 @@ part of task_tree;
 const _basicAnimations = TaskBlueprint(
   "Basic Animations",
   {Skill.ux: 100},
-  requirements: AnyOf([_programmerArtUI, _basicUI]),
+  requirements: AllOf([_alpha]),
 );
 
 const _advancedMotionDesign = TaskBlueprint(

--- a/lib/src/shared_state/game/task_tree/backend_infrastructure.dart
+++ b/lib/src/shared_state/game/task_tree/backend_infrastructure.dart
@@ -5,3 +5,15 @@ const _backendInfrastructure = TaskBlueprint(
   {Skill.engineering: 100, Skill.coding: 100},
   requirements: AllOf([_alpha]),
 );
+
+const _fastBackend = TaskBlueprint(
+  "Fast Backend",
+  {Skill.coding: 100},
+  requirements: AllOf([_backendInfrastructure]),
+);
+
+const _scalableBackend = TaskBlueprint(
+  "Scalable backend",
+  {Skill.coding: 100},
+  requirements: AllOf([_backendInfrastructure]),
+);

--- a/lib/src/shared_state/game/task_tree/beta.dart
+++ b/lib/src/shared_state/game/task_tree/beta.dart
@@ -11,15 +11,6 @@ const _beta = TaskBlueprint(
     AnyOf([_retroDesign, _scifiDesign, _mainstreamDesign]),
     // Color theme.
     AnyOf([_redTheme, _greenTheme, _blueTheme]),
-    // An important feature.
-    AnyOf([
-      _advancedMotionDesign,
-      _accessibility,
-      _internationalization,
-      _animatedGifSupport,
-      _imageFilters,
-      _memeGenerator,
-      _arMessages
-    ]),
   ]),
+  priority: 100,
 );

--- a/lib/src/shared_state/game/task_tree/design.dart
+++ b/lib/src/shared_state/game/task_tree/design.dart
@@ -4,64 +4,53 @@ const _basicDesign = TaskBlueprint(
   "Basic Design",
   {Skill.ux: 100, Skill.coordination: 50},
   requirements: AllOf([_alpha]),
+  priority: 50,
 );
 
 const _dinosaurMascot = TaskBlueprint(
   "Dinosaur Mascot & Icon",
   {Skill.coordination: 100, Skill.ux: 50},
-  requirements: AllOf([
-    _basicDesign,
-    Not("Bird Mascot & Icon"),
-    Not("Cat Mascot & Icon"),
-  ]),
+  requirements: AllOf([_basicDesign]),
+  mutuallyExclusive: ["Bird Mascot & Icon", "Cat Mascot & Icon"],
+  priority: 10,
 );
 
 const _birdMascot = TaskBlueprint(
   "Bird Mascot & Icon",
   {Skill.coordination: 100, Skill.ux: 50},
-  requirements: AllOf([
-    _basicDesign,
-    Not("Cat Mascot & Icon"),
-    Not("Dinosaur Mascot & Icon"),
-  ]),
+  requirements: AllOf([_basicDesign]),
+  mutuallyExclusive: ["Cat Mascot & Icon", "Dinosaur Mascot & Icon"],
+  priority: 10,
 );
 
 const _catMascot = TaskBlueprint(
   "Cat Mascot & Icon",
   {Skill.coordination: 100, Skill.ux: 50},
-  requirements: AllOf([
-    _basicDesign,
-    Not("Bird Mascot & Icon"),
-    Not("Dinosaur Mascot & Icon"),
-  ]),
+  requirements: AllOf([_basicDesign]),
+  mutuallyExclusive: ["Bird Mascot & Icon", "Dinosaur Mascot & Icon"],
+  priority: 10,
 );
 
 const _retroDesign = TaskBlueprint(
   "Retro Design",
   {Skill.ux: 100},
-  requirements: AllOf([
-    _basicDesign,
-    Not("Sci-Fi Design"),
-    Not("Mainstream Design"),
-  ]),
+  requirements: AllOf([_basicDesign]),
+  mutuallyExclusive: ["Sci-Fi Design", "Mainstream Design"],
+  priority: 10,
 );
 
 const _scifiDesign = TaskBlueprint(
   "Sci-Fi Design",
   {Skill.ux: 100},
-  requirements: AllOf([
-    _basicDesign,
-    Not("Retro Design"),
-    Not("Mainstream Design"),
-  ]),
+  requirements: AllOf([_basicDesign]),
+  mutuallyExclusive: ["Retro Design", "Mainstream Design"],
+  priority: 10,
 );
 
 const _mainstreamDesign = TaskBlueprint(
   "Mainstream Design",
   {Skill.ux: 50},
-  requirements: AllOf([
-    _basicDesign,
-    Not("Sci-Fi Design"),
-    Not("Retro Design"),
-  ]),
+  requirements: AllOf([_basicDesign]),
+  mutuallyExclusive: ["Sci-Fi Design", "Retro Design"],
+  priority: 10,
 );

--- a/lib/src/shared_state/game/task_tree/launch.dart
+++ b/lib/src/shared_state/game/task_tree/launch.dart
@@ -15,4 +15,5 @@ const _launch = TaskBlueprint(
       _uiPolish,
     ]),
   ]),
+  priority: 100,
 );

--- a/lib/src/shared_state/game/task_tree/pre_alpha.dart
+++ b/lib/src/shared_state/game/task_tree/pre_alpha.dart
@@ -1,51 +1,30 @@
 part of task_tree;
 
-const _backendPrototype = TaskBlueprint(
-  "Backend Prototype",
+const _prototype = TaskBlueprint(
+  "Prototype",
+  {Skill.coding: 30},
+  requirements: none,
+);
+
+const _basicBackend = TaskBlueprint(
+  "Basic Backend",
   {Skill.coding: 100},
-  requirements: AllOf([_pretendotype]),
+  requirements: AllOf([_prototype]),
+  priority: 10,
 );
 
 const _basicUI = TaskBlueprint(
   "Basic UI",
   {Skill.ux: 100},
-  requirements: AllOf([_workingPrototype, Not("Programmer Art UI")]),
-);
-
-const _fastBackend = TaskBlueprint(
-  "Fast Backend",
-  {Skill.coding: 100},
-  requirements: AllOf([_backendPrototype]),
-);
-
-const _pretendotype = TaskBlueprint(
-  "Pretendotype",
-  {Skill.ux: 50, Skill.coordination: 20},
-  requirements: none,
+  requirements: AllOf([_prototype]),
+  mutuallyExclusive: ["Programmer Art UI"],
 );
 
 const _programmerArtUI = TaskBlueprint(
   "Programmer Art UI",
   {Skill.coding: 100},
-  requirements: AllOf([_workingPrototype, Not("Basic UI")]),
-);
-
-const _scalableBackend = TaskBlueprint(
-  "Scalable backend",
-  {Skill.coding: 100},
-  requirements: AllOf([_backendPrototype]),
-);
-
-const _uiPrototype = TaskBlueprint(
-  "UI Prototype",
-  {Skill.coding: 100},
-  requirements: AllOf([_pretendotype]),
-);
-
-const _workingPrototype = TaskBlueprint(
-  "Working Prototype",
-  {Skill.coding: 100},
-  requirements: AllOf([_uiPrototype, _backendPrototype]),
+  requirements: AllOf([_prototype]),
+  mutuallyExclusive: ["Basic UI"],
 );
 
 const _alpha = TaskBlueprint(
@@ -53,6 +32,7 @@ const _alpha = TaskBlueprint(
   {Skill.coordination: 100, Skill.coding: 100},
   requirements: AllOf([
     AnyOf([_programmerArtUI, _basicUI]),
-    AnyOf([_scalableBackend, _fastBackend]),
+    _basicBackend,
   ]),
+  priority: 100,
 );

--- a/lib/src/shared_state/game/task_tree/pre_launch.dart
+++ b/lib/src/shared_state/game/task_tree/pre_launch.dart
@@ -4,34 +4,40 @@ const _backendPerformanceOptimization = TaskBlueprint(
   "Backend Performance Optimization",
   {Skill.engineering: 100, Skill.coding: 100},
   requirements: AllOf([_beta, _fastBackend]),
+  priority: 50,
 );
 
 const _backendScalabilityOptimization = TaskBlueprint(
   "Backend Scalability Optimization",
   {Skill.engineering: 100, Skill.coding: 100},
   requirements: AllOf([_beta, _scalableBackend]),
+  priority: 50,
 );
 
 const _prelaunchMarketing = TaskBlueprint(
   "Pre-launch Marketing",
   {Skill.coordination: 100},
   requirements: AllOf([_beta]),
+  priority: 50,
 );
 
 const _backendHardening = TaskBlueprint(
   "Backend Hardening",
   {Skill.engineering: 100, Skill.coding: 100},
   requirements: AllOf([_beta]),
+  priority: 50,
 );
 
 const _uiPerformanceOptimization = TaskBlueprint(
   "UI Performance Optimization",
   {Skill.coding: 100, Skill.ux: 50},
   requirements: AllOf([_beta]),
+  priority: 50,
 );
 
 const _uiPolish = TaskBlueprint(
   "UI Polish",
   {Skill.coding: 100, Skill.ux: 100},
   requirements: AllOf([_beta]),
+  priority: 50,
 );

--- a/lib/src/shared_state/game/task_tree/task_tree.dart
+++ b/lib/src/shared_state/game/task_tree/task_tree.dart
@@ -25,6 +25,8 @@ const Set<TaskBlueprint> taskTree = {
   _advancedMotionDesign,
   // backend_infrastructure.dart
   _backendInfrastructure,
+  _fastBackend,
+  _scalableBackend,
   // beta.dart
   _beta,
   // design.dart
@@ -52,14 +54,10 @@ const Set<TaskBlueprint> taskTree = {
   _automatedBots,
   _conversationalChatbots,
   // pre_alpha.dart
-  _backendPrototype,
+  _prototype,
   _basicUI,
-  _fastBackend,
-  _pretendotype,
+  _basicBackend,
   _programmerArtUI,
-  _scalableBackend,
-  _uiPrototype,
-  _workingPrototype,
   _alpha,
   // pre_launch.dart
   _backendPerformanceOptimization,

--- a/lib/src/shared_state/game/task_tree/theme.dart
+++ b/lib/src/shared_state/game/task_tree/theme.dart
@@ -4,34 +4,29 @@ const _basicTheme = TaskBlueprint(
   "Basic Theme",
   {Skill.ux: 100, Skill.coordination: 50},
   requirements: AllOf([_alpha]),
+  priority: 50,
 );
 
 const _greenTheme = TaskBlueprint(
   "Green Theme",
   {Skill.ux: 50},
-  requirements: AllOf([
-    _basicTheme,
-    Not("Red Theme"),
-    Not("Blue Theme"),
-  ]),
+  requirements: AllOf([_basicTheme]),
+  mutuallyExclusive: ["Red Theme", "Blue Theme"],
+  priority: 10,
 );
 
 const _redTheme = TaskBlueprint(
   "Red Theme",
   {Skill.ux: 50},
-  requirements: AllOf([
-    _basicTheme,
-    Not("Green Theme"),
-    Not("Blue Theme"),
-  ]),
+  requirements: AllOf([_basicTheme]),
+  mutuallyExclusive: ["Green Theme", "Blue Theme"],
+  priority: 10,
 );
 
 const _blueTheme = TaskBlueprint(
   "Blue Theme",
   {Skill.ux: 50},
-  requirements: AllOf([
-    _basicTheme,
-    Not("Green Theme"),
-    Not("Red Theme"),
-  ]),
+  requirements: AllOf([_basicTheme]),
+  mutuallyExclusive: ["Green Theme", "Red Theme"],
+  priority: 10,
 );


### PR DESCRIPTION
This removes a few tasks, but — more importantly — loses some of the requirements, and lists tasks by priority, making it much easier to select the critical path tasks.

This also prevents the player from selecting a task that is mutually exclusive with a task that they are already working.

Merging immediately, TBR.

cc @luigi-rosso, @efortuna 