### PR TITLE
Iteration on work_list_item.dart for Beyond Mobile live coding

### DIFF
--- a/lib/src/widgets/work_items/work_list_item.dart
+++ b/lib/src/widgets/work_items/work_list_item.dart
@@ -135,7 +135,7 @@ class TeamProgressIndicator extends StatelessWidget {
                 team: workItem.assignedTeam,
                 skillsNeeded: workItem.skillsNeeded,
                 isComplete: workItem.isComplete,
-              )
+              ),
             ],
           );
   }


### PR DESCRIPTION
- Removes single-child Column and Stack from WorkListItem build function-- as far as I could tell, these weren't having any effect. No other logic changes.
- Breaks out TeamProgressIndicator into a separate Widget (no logic changes)
- Adds some trailing commas for formatting standardization
- Adds comments reflecting which pieces of this file will be live-coded. Happy to remove these if others would prefer we keep separate.

PTAL!