### PR TITLE
Add an ignore pointer to fix scrolling on character pool page.

### DIFF
--- a/lib/src/game_screen/character_pool_page.dart
+++ b/lib/src/game_screen/character_pool_page.dart
@@ -43,18 +43,20 @@ class CharacterPoolPage extends StatelessWidget {
       child: Align(
         alignment: Alignment.bottomCenter,
         heightFactor: 1.0,
-        child: Container(
-          height: 128,
-          decoration: BoxDecoration(
-            // Box decoration takes a gradient
-            gradient: const LinearGradient(
-              begin: Alignment.topCenter,
-              end: Alignment.bottomCenter,
-              colors: [
-                Color.fromRGBO(59, 59, 73, 0.0),
-                Color.fromRGBO(59, 59, 73, 1.0)
-              ],
-              stops: [0.0, 1.0],
+        child: IgnorePointer(
+          child: Container(
+            height: 128,
+            decoration: BoxDecoration(
+              // Box decoration takes a gradient
+              gradient: const LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  Color.fromRGBO(59, 59, 73, 0.0),
+                  Color.fromRGBO(59, 59, 73, 1.0)
+                ],
+                stops: [0.0, 1.0],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
This is a fix for issue #35. Just wrapping the Container in an IgnorePointer seems to do the trick.