### PR TITLE
Perf tweak (doubled Nokia 6 framerate).

### DIFF
--- a/lib/src/widgets/flare/hiring_bust.dart
+++ b/lib/src/widgets/flare/hiring_bust.dart
@@ -177,9 +177,9 @@ class HiringBustRenderObject extends FlareRenderBox {
             offset.dy + size.height / 2.0 - clipDiameter / 2.0) &
         Size(clipDiameter, clipDiameter));
 
-	// There's something about using a large clipping area that seems to 
-	// negatively affect performance. Keeping this here as reference for the
-	// intended look of the app.
+    // There's something about using a large clipping area that seems to
+    // negatively affect performance. Keeping this here as reference for the
+    // intended look of the app.
     // clip.addRect(const Offset(0.0, 0.0) &
     //     Size(ui.window.physicalSize.width, offset.dy + size.height / 1.25));
     canvas.clipPath(clip);


### PR DESCRIPTION
Disable rectangular region of hiring bust clip path.