### PR TITLE
Fix Character Modal Overflow

### DIFF
--- a/lib/src/game_screen/character_modal.dart
+++ b/lib/src/game_screen/character_modal.dart
@@ -38,7 +38,7 @@ class CharacterModal extends StatelessWidget {
           child: ConstrainedBox(
             constraints: const BoxConstraints(minWidth: 280.0),
             child: Column(mainAxisSize: MainAxisSize.min, children: [
-              Expanded(child: CharacterImage(_controls)),
+              CharacterImage(_controls),
               CharacterStats(_controls)
             ]),
           ),
@@ -56,43 +56,45 @@ class CharacterImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     var characterStyle = CharacterStyle.from(Provider.of<Character>(context));
-    return Stack(
-      children: [
-        Positioned.fill(
-          child: Container(
-            decoration: const BoxDecoration(
-              color: Color.fromRGBO(241, 241, 241, 1.0),
-              borderRadius: BorderRadius.only(
-                topLeft: Radius.circular(10.0),
-                topRight: Radius.circular(10.0),
+    return Expanded(
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: Container(
+              decoration: const BoxDecoration(
+                color: Color.fromRGBO(241, 241, 241, 1.0),
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(10.0),
+                  topRight: Radius.circular(10.0),
+                ),
               ),
             ),
           ),
-        ),
-        Positioned.fill(
-          child: FlareActor(characterStyle.flare,
-              alignment: Alignment.bottomCenter,
-              shouldClip: false,
-              fit: BoxFit.cover,
-              animation: "idle",
-              controller: _controls),
-        ),
-        Align(
-          alignment: Alignment.topRight,
-          child: ButtonTheme(
-            minWidth: 0.0,
-            child: FlatButton(
-              padding: const EdgeInsets.all(0.0),
-              shape: null,
-              onPressed: () => Navigator.pop(context, null),
-              child: const Icon(
-                Icons.cancel,
-                color: Color.fromRGBO(69, 69, 82, 1.0),
+          Positioned.fill(
+            child: FlareActor(characterStyle.flare,
+                alignment: Alignment.bottomCenter,
+                shouldClip: false,
+                fit: BoxFit.cover,
+                animation: "idle",
+                controller: _controls),
+          ),
+          Align(
+            alignment: Alignment.topRight,
+            child: ButtonTheme(
+              minWidth: 0.0,
+              child: FlatButton(
+                padding: const EdgeInsets.all(0.0),
+                shape: null,
+                onPressed: () => Navigator.pop(context, null),
+                child: const Icon(
+                  Icons.cancel,
+                  color: Color.fromRGBO(69, 69, 82, 1.0),
+                ),
               ),
             ),
-          ),
-        )
-      ],
+          )
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
Fix character modal overflow by expanding the entire modal and allowing the hero to use whatever is left over after the stats consume their space.

Addresses issue #40.