### PR TITLE
Use dev branch for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: Install Flutter
           command: |
-            git clone https://github.com/flutter/flutter.git -b master
+            git clone https://github.com/flutter/flutter.git -b dev
             ./flutter/bin/flutter doctor
             ./flutter/bin/flutter packages get
 


### PR DESCRIPTION
Looks like the test is still failing (it fails locally for me on `dev` branch as well).

That said, probs still a good idea to get everyone on `dev` for the remainder of this journey to avoid conflicting analysis errors or the like!