### PR TITLE
Changing Flare dependency to use git.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   flare_flutter:
     git: 
       url: git://github.com/2d-inc/Flare-Flutter.git
-      ref: dev
+      ref: 2ec15af0042696de7d997cbfdcb6deaf55463af2
       path: flare_flutter
   auto_size_text: ^1.1.2
 


### PR DESCRIPTION
The latest dev has breaking changes in the api Flare uses to draw texture mapped meshes. In order to not break our pub package working on stable, we need to use a git reference to flare_flutter's bleeding edge code. 

This also allows us to use [compute](https://docs.flutter.io/flutter/foundation/compute.html) which also has api and functional changes to allow it to work with async functions. This helps reduce the jank when loading Flare files as reported in issue #31.

By the way, I didn't include this in the PR but I locally had to bump my Dart SDK version (I upgraded dev channel this morning):
```
The current Dart SDK version is 2.3.0-dev.0.1.flutter-1f1592edce.

Because dev_rpg requires SDK version >=2.3.0-dev.0.1.flutter-cf4444b803, version solving failed.
```