### PR TITLE
Animate when switching between tabs

### DIFF
--- a/lib/src/game_screen_slim.dart
+++ b/lib/src/game_screen_slim.dart
@@ -1,7 +1,7 @@
 import 'package:dev_rpg/src/game_screen/character_pool_page.dart';
 import 'package:dev_rpg/src/game_screen/task_pool_page.dart';
-import 'package:dev_rpg/src/shared_state/game/company.dart';
 import 'package:dev_rpg/src/shared_state/game/character_pool.dart';
+import 'package:dev_rpg/src/shared_state/game/company.dart';
 import 'package:dev_rpg/src/style.dart';
 import 'package:dev_rpg/src/widgets/app_bar/coin_badge.dart';
 import 'package:dev_rpg/src/widgets/app_bar/joy_badge.dart';
@@ -37,7 +37,11 @@ class GameScreenSlimState extends State<GameScreenSlim> {
     setState(() {
       _index = index;
     });
-    _controller.jumpToPage(index);
+    _controller.animateToPage(
+      index,
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOutCubic,
+    );
   }
 
   @override


### PR DESCRIPTION
This just asks the PageView to animate to the requested page instead of jumping to it. This teaches the user that the tabs are actually swipable.

![screencapture-1556581307375 2019-04-29 16_43_57](https://user-images.githubusercontent.com/919717/56933823-436b6700-6a9e-11e9-885f-d3e2123da90f.gif)

I've wanted to do this since the very beginning but never got to it until just now.