### PR TITLE
 Disable landscape on phones.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
+import 'dart:ui' as ui;
 
 import 'package:dev_rpg/src/about_screen.dart';
 import 'package:dev_rpg/src/code_chomper/code_chomper.dart';
 import 'package:dev_rpg/src/game_screen.dart';
 import 'package:dev_rpg/src/shared_state/game/world.dart';
 import 'package:dev_rpg/src/shared_state/user.dart';
+import 'package:dev_rpg/src/style.dart';
 import 'package:dev_rpg/src/style_sphinx/axis_questions.dart';
 import 'package:dev_rpg/src/style_sphinx/flex_questions.dart';
 import 'package:dev_rpg/src/style_sphinx/kittens.dart';
@@ -20,6 +22,16 @@ void main() {
   // Don't prune the Flare cache, keep loaded Flare files warm and ready
   // to be re-displayed.
   FlareCache.doesPrune = false;
+
+  var window = ui.window;
+  var width = window.physicalSize.width / window.devicePixelRatio;
+  if (width < blockLandscapeThreshold) {
+    // Disallow rotating to landscape.
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.portraitUp,
+      DeviceOrientation.portraitDown,
+    ]);
+  }
 
   runApp(MyApp());
 }

--- a/lib/src/style.dart
+++ b/lib/src/style.dart
@@ -11,10 +11,28 @@ const Color disabledTaskColor = Color.fromRGBO(38, 38, 47, 0.25);
 const Color treeLineColor = Color.fromRGBO(215, 215, 215, 1);
 const Color bugColor = Color.fromRGBO(236, 41, 117, 1);
 const Color statsSeparatorColor = Color.fromRGBO(57, 57, 71, 1);
+
+/// Maximum logical pixel width for a modal window.
 const double modalMaxWidth = 400;
+
+/// Once the logic screen pixel width exceeds this number, show the ultrawide
+/// layout.
 const double ultraWideLayoutThreshold = 1920;
-const double wideLayoutThreshold = 500;
+
+/// Once the logic screen pixel width exceeds this number, show the wide layout.
+const double wideLayoutThreshold = 800;
+
+/// Devices with a logical screen pixel width less than this value
+/// will not be permitted to rotate into landscape mode.
+const double blockLandscapeThreshold = 750;
+
+/// Ideal width of a character cell in the character hiring grid. This is used
+/// to compute the number of columns to display when viewing the character grid.
 const double idealCharacterWidth = 165;
+
+/// Ideal diameter of a particle in the hiring effect. The actual drawn particle
+/// size is computed based on a ratio of this diameter to the ideal character
+/// multiplied by the actual character width displayed.
 const double idealParticleSize = 10;
 
 const TextStyle contentSmallStyle = TextStyle(


### PR DESCRIPTION
I've already pushed this to the demo branch along with the chrome hiding (I removed it here just in case, I don't think we want to risk certain devices having fullscreen enabled). We've tested it on a few different devices and tablets, it seems to be working well. The objective was:

Phones only allow portrait mode.
Tablets allow portrait and landscape.
Tablets which are slim should show the slim layout in portrait mode (basically avoid any content overflowing).

We've tested on all the iPads and iPhones in the simulator and a few Android tablets and phones (including the Pixel, Pixel 2, Nexus 9, Nokia 6, Samsung S8).