### PR TITLE
Remove the SDK version pin

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,10 @@
 import 'dart:async';
-import 'dart:ui' as ui;
 
 import 'package:dev_rpg/src/about_screen.dart';
 import 'package:dev_rpg/src/code_chomper/code_chomper.dart';
 import 'package:dev_rpg/src/game_screen.dart';
 import 'package:dev_rpg/src/shared_state/game/world.dart';
 import 'package:dev_rpg/src/shared_state/user.dart';
-import 'package:dev_rpg/src/style.dart';
 import 'package:dev_rpg/src/style_sphinx/axis_questions.dart';
 import 'package:dev_rpg/src/style_sphinx/flex_questions.dart';
 import 'package:dev_rpg/src/style_sphinx/kittens.dart';

--- a/lib/src/game_screen/team_picker_modal.dart
+++ b/lib/src/game_screen/team_picker_modal.dart
@@ -90,8 +90,8 @@ class TeamPickerModalState extends State<TeamPickerModal> {
                           builder: (context, characterPool, child) {
                             var characters = characterPool.fullTeam;
                             return characters.isEmpty
-                                ? Center(
-                                    child: const Text(
+                                ? const Center(
+                                    child: Text(
                                       'Hire some teammates to complete '
                                       'this task!',
                                       style: contentLargeStyle,

--- a/lib/src/shared_state/game/task_tree/task_tree.dart
+++ b/lib/src/shared_state/game/task_tree/task_tree.dart
@@ -116,6 +116,8 @@ class TaskNode implements TreeData {
       // We have to do this because some items (like _advancedMotionDesign)
       // are only satisfied when multiple non-direct descendent items in the
       // tree are satisfied.
+      //
+      // ignore: literal_only_boolean_expressions
       while (true) {
         var patched = false;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,8 +13,7 @@ environment:
   # For Google I/O we are being very specific about pinning to specific branch revision.
   # This is flutter commit hash b593f5167bce84fb3cad5c258477bf3abc1b14eb, tagged
   # as Flutter version 1.5.4.
-  #sdk: ">=2.3.0-dev.0.1 <3.0.0"
-  sdk: "2.3.0-dev.0.1.flutter-cf4444b803"
+  sdk: ">=2.3.0-dev.0.1 <3.0.0"
 
 dependencies:
   flutter:

--- a/test/character_test.dart
+++ b/test/character_test.dart
@@ -25,7 +25,7 @@ void main() {
   });
 
   test('level goes up when upgraded', () {
-    var world = World()..company.coin.number = 1000;
+    var world = World()..company.coin.number = 10000;
     // Find the first available character that we can hire.
     var character = world.characterPool.children
         .firstWhere((ch) => !ch.isHired && ch.canUpgradeOrHire);
@@ -36,7 +36,7 @@ void main() {
   });
 
   test('skill goes up when upgraded', () {
-    var world = World()..company.coin.number = 1000;
+    var world = World()..company.coin.number = 10000;
     // Find the first available character that we can hire.
     var character = world.characterPool.children
         .firstWhere((ch) => !ch.isHired && ch.canUpgradeOrHire);


### PR DESCRIPTION
The SDK version pin is not needed anymore — we’ve launched both the app and Flutter 1.5 stable.