### PR TITLE
Correct casing of paintDirty flag

### DIFF
--- a/lib/src/widgets/flare/desaturated_actor.dart
+++ b/lib/src/widgets/flare/desaturated_actor.dart
@@ -13,7 +13,7 @@ class DesaturatedActor extends FlutterActor {
       return;
     }
     _desaturate = value;
-    artboard.addDirt(artboard.root, DirtyFlags.PaintDirty, true);
+    artboard.addDirt(artboard.root, DirtyFlags.paintDirty, true);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
-  flare_flutter: ^1.5.5
+  flare_flutter: ^1.8.3
   auto_size_text: ^1.1.2
 
 dev_dependencies:


### PR DESCRIPTION
**Expected**
Project can be built shortly after clone.

**Actual**
```
$fl build appbundle
Initializing gradle...                                              0.6s
Resolving dependencies...                                           1.3s
                                                                        
Compiler message:                                                       
lib/src/widgets/flare/desaturated_actor.dart:16:48: Error: Getter not found: 'PaintDirty'.
    artboard.addDirt(artboard.root, DirtyFlags.PaintDirty, true);       
                                               ^^^^^^^^^^               
Compiler terminated unexpectedly.                                       
                                                                        
FAILURE: Build failed with an exception.                                
                                                                        
* Where:                                                                
Script '/home/bean/bin/flutter/packages/flutter_tools/gradle/flutter.gradle' line: 739
                                                                        
* What went wrong:                                                      
Execution failed for task ':app:compileFlutterBuildReleaseArm'.         
> Process 'command '/home/bean/bin/flutter/bin/flutter'' finished with non-zero exit value 1
                                                                        
* Try:                                                                  
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
                                                                        
* Get more help at https://help.gradle.org                              
                                                                        
BUILD FAILED in 8s                                                      
Running Gradle task 'bundleRelease'...                                  
Running Gradle task 'bundleRelease'... Done                         9.0s
Gradle task bundleRelease failed with exit code 1
```