### PR TITLE
Make documentation less ambiguous about location of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ All in Flutter.
 ## Research tree
 
 The game progression is based on a "research tree" of tasks. The tree is defined in code
-in `lib/src/shared_state/task_tree` but for clarity it is also kept as a diagram
-in `assets/docs`. Here's the PNG.
+in `lib/src/shared_state/task_tree/` but for clarity it is also kept as a diagram
+in `assets/docs/`. Here's the PNG.
 
 ![The task "research tree"](https://github.com/2d-inc/dev_rpg/blob/master/assets/docs/research-tree.png)
 


### PR DESCRIPTION
Simple fix. Just added some slashes.

Also, I had this at #146, but I accidentally closed it.

@luigi-rosso 