### PR TITLE
Replace deprecated display1 by headline4

### DIFF
--- a/assets/docs/code_chomper_beta.dart
+++ b/assets/docs/code_chomper_beta.dart
@@ -48,7 +48,7 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             Text(
               '$_counter',
-              style: Theme.of(context).textTheme.display1,
+              style: Theme.of(context).textTheme.headline4,
             ),
           ],
         ),


### PR DESCRIPTION
code_chomper_beta: Replaced deprecated 'display1' for modern term 'headline4'